### PR TITLE
DXP-1310 Make direct-db update tests always rollback their changes

### DIFF
--- a/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/AttributeAddAndDeleteTest.php
+++ b/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/AttributeAddAndDeleteTest.php
@@ -15,17 +15,19 @@ class AttributeAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
     }
 
     /** @test */
-    public function shouldPublishAttributeAddedUsingMagentoApplicationToStreamx_AndUnpublishDeletedAttribute() {
+    public function shouldPublishAttributeAddedDirectlyInDatabaseToStreamx_AndUnpublishDeletedAttribute() {
         // given
         $attributeCode = 'the_new_attribute';
 
         // when
         $attributeId = self::insertNewAttribute($attributeCode);
-        $this->reindexMview();
-
-        // then
         $expectedKey = "attribute_$attributeId";
+
         try {
+            // and
+            $this->reindexMview();
+
+            // then
             $this->assertDataIsPublished($expectedKey, $attributeCode);
         } finally {
             // and when

--- a/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/AttributeUpdateTest.php
+++ b/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/AttributeUpdateTest.php
@@ -30,10 +30,12 @@ class AttributeUpdateTest extends BaseDirectDbEntityUpdateTest {
 
         // when
         self::renameAttributeInDb($attributeId, $newDisplayName);
-        $this->reindexMview();
 
-        // then
         try {
+            // and
+            $this->reindexMview();
+
+            // then
             $this->assertDataIsPublished($expectedKey, $newDisplayName);
         } finally {
             self::renameAttributeInDb($attributeId, $oldDisplayName);

--- a/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/CategoryAddAndDeleteTest.php
+++ b/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/CategoryAddAndDeleteTest.php
@@ -15,17 +15,19 @@ class CategoryAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
     }
 
     /** @test */
-    public function shouldPublishCategoryAddedUsingMagentoApplicationToStreamx_AndUnpublishDeletedCategory() {
+    public function shouldPublishCategoryAddedDirectlyInDatabaseToStreamx_AndUnpublishDeletedCategory() {
         // given
         $categoryName = 'The new Category';
 
         // when
         $categoryId = self::insertNewCategory($categoryName);
-        $this->reindexMview();
-
-        // then
         $expectedKey = "category_$categoryId";
+
         try {
+            // and
+            $this->reindexMview();
+
+            // then
             $this->assertDataIsPublished($expectedKey, $categoryName);
         } finally {
             // and when

--- a/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/CategoryUpdateTest.php
+++ b/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/CategoryUpdateTest.php
@@ -28,10 +28,12 @@ class CategoryUpdateTest extends BaseDirectDbEntityUpdateTest {
 
         // when
         self::renameCategoryInDb($categoryId, $categoryNewName);
-        $this->reindexMview();
 
-        // then
         try {
+            // and
+            $this->reindexMview();
+
+            // then
             $this->assertDataIsPublished($expectedKey, $categoryNewName);
         } finally {
             self::renameCategoryInDb($categoryId, $categoryOldName);

--- a/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/ProductAddAndDeleteTest.php
+++ b/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/ProductAddAndDeleteTest.php
@@ -23,11 +23,13 @@ class ProductAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
 
         // when
         $productId = self::insertNewProduct($productName, $watchesCategoryId);
-        $this->reindexMview();
-
-        // then
         $expectedKey = "product_$productId";
+
         try {
+            // and
+            $this->reindexMview();
+
+            // then
             $this->assertDataIsPublished($expectedKey, $productName);
         } finally {
             // and when
@@ -51,17 +53,15 @@ class ProductAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
         $product1Id = self::insertNewProduct($product1Name, $watchesCategoryId);
         $product2Id = self::insertNewProduct($product2Name, $watchesCategoryId);
         $product3Id = self::insertNewProduct($product3Name, $watchesCategoryId);
-        $this->reindexMview();
-
-        // then
-        $expectedProduct1Key = 'product_' . $product1Id;
-        $expectedProduct2Key = 'product_' . $product2Id;
-        $expectedProduct3Key = 'product_' . $product3Id;
 
         try {
-            $this->assertDataIsPublished($expectedProduct1Key, $product1Name);
-            $this->assertDataIsPublished($expectedProduct2Key, $product2Name);
-            $this->assertDataIsPublished($expectedProduct3Key, $product3Name);
+            // and
+            $this->reindexMview();
+
+            // then
+            $this->assertDataIsPublished("product_$product1Id", $product1Name);
+            $this->assertDataIsPublished("product_$product2Id", $product2Name);
+            $this->assertDataIsPublished("product_$product3Id", $product3Name);
         } finally {
             // and when
             self::deleteProduct($product1Id);
@@ -70,9 +70,9 @@ class ProductAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
             $this->reindexMview();
 
             // then
-            $this->assertDataIsUnpublished($expectedProduct1Key);
-            $this->assertDataIsUnpublished($expectedProduct2Key);
-            $this->assertDataIsUnpublished($expectedProduct3Key);
+            $this->assertDataIsUnpublished("product_$product1Id");
+            $this->assertDataIsUnpublished("product_$product2Id");
+            $this->assertDataIsUnpublished("product_$product3Id");
         }
     }
 

--- a/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/ProductCategoryUpdateTest.php
+++ b/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/ProductCategoryUpdateTest.php
@@ -40,10 +40,12 @@ class ProductCategoryUpdateTest extends BaseDirectDbEntityUpdateTest {
 
         // when
         self::changeProductCategoryInDb($productId, $oldCategoryId, $newCategoryId);
-        $this->reindexMview();
 
-        // then
         try {
+            // and
+            $this->reindexMview();
+
+            // then
             $this->assertDataIsPublished($expectedKey, $newCategoryName);
         } finally {
             self::changeProductCategoryInDb($productId, $newCategoryId, $oldCategoryId);

--- a/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/ProductUpdateTest.php
+++ b/src/catalog/test/integration/DirectDbEntityUpdateStreamxPublishTests/ProductUpdateTest.php
@@ -28,10 +28,12 @@ class ProductUpdateTest extends BaseDirectDbEntityUpdateTest {
 
         // when
         self::renameProductInDb($productId, $productNewName);
-        $this->reindexMview();
 
-        // then
         try {
+            // and
+            $this->reindexMview();
+
+            // then
             $this->assertDataIsPublished($expectedKey, $productNewName);
         } finally {
             self::renameProductInDb($productId, $productOldName);


### PR DESCRIPTION
## 📋 Type of the changes

- [ ] Breaking change
- [x] Non-breaking change
- [ ] Bug fix / minor change

## 🛠 Changes being made

Improve integration tests stability

## ✅ Checklist

- [ ] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [x] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
