### PR TITLE
DXP-1719 Tighten json-based validation: adjust only actual json to match validation file, not both

### DIFF
--- a/test/catalog/integration/AppEntityUpdateStreamxPublishTests/CategoryAddAndDeleteTest.php
+++ b/test/catalog/integration/AppEntityUpdateStreamxPublishTests/CategoryAddAndDeleteTest.php
@@ -21,9 +21,9 @@ class CategoryAddAndDeleteTest extends BaseAppEntityUpdateTest {
         try {
             $this->assertExactDataIsPublished($expectedKey, 'added-category.json', [
                 // provide values for placeholders in the validation file
-                123456789 => $categoryId,
-                'CATEGORY_NAME' => 'The new Category',
-                'CATEGORY_SLUG' => "the-new-category-$categoryId"
+                '"id": ' . $categoryId => '"id": 123456789',
+                'The new Category' => 'CATEGORY_NAME',
+                "the-new-category-$categoryId" => 'CATEGORY_SLUG'
             ]);
         } finally {
             // and when

--- a/test/catalog/integration/AppEntityUpdateStreamxPublishTests/ProductAddAndDeleteTest.php
+++ b/test/catalog/integration/AppEntityUpdateStreamxPublishTests/ProductAddAndDeleteTest.php
@@ -27,9 +27,9 @@ class ProductAddAndDeleteTest extends BaseAppEntityUpdateTest {
         try {
             $publishedJson = $this->assertExactDataIsPublished($expectedKey, 'added-watch-product-without-custom-options.json', [
                 // mask variable parts (ids and generated sku)
-                '"id": [0-9]+' => '"id": 0',
-                '"sku": "[^"]+"' => '"sku": "[MASKED]"',
-                '"the-new-great-watch-[0-9]+"' => '"the-new-great-watch-0"'
+                '"id": [0-9]{4}' => '"id": 2659',
+                '"sku": "[^"]+"' => '"sku": "1736952738"',
+                '"the-new-great-watch-[0-9]+"' => '"the-new-great-watch-2659"'
             ]);
 
             // and

--- a/test/catalog/integration/AppEntityUpdateStreamxPublishTests/ProductUpdateTest.php
+++ b/test/catalog/integration/AppEntityUpdateStreamxPublishTests/ProductUpdateTest.php
@@ -29,8 +29,8 @@ class ProductUpdateTest extends BaseAppEntityUpdateTest {
     /** @test */
     public function shouldPublishBundleProductEditedUsingMagentoApplicationToStreamx() {
         $regexReplacements = self::$db->isEnterpriseMagento() ? [ // in enterprise magento DB, ID of the bundle product is 46, not 45 as in community version
-            '"id": 45,' => '"id": 46,',
-            '-45"' => '-46"'
+            '"id": 46,' => '"id": 45,',
+            '-46"' => '-45"'
         ] : [];
         $this->shouldPublishProductEditedUsingMagentoApplicationToStreamx('Sprite Yoga Companion Kit', 'bundle', $regexReplacements);
     }
@@ -38,8 +38,8 @@ class ProductUpdateTest extends BaseAppEntityUpdateTest {
     /** @test */
     public function shouldPublishGroupedProductEditedUsingMagentoApplicationToStreamx() {
         $regexReplacements = self::$db->isEnterpriseMagento() ? [ // in enterprise magento DB, ID of the grouped product is 45, not 46 as in community version
-            '"id": 46,' => '"id": 45,',
-            '-46"' => '-45"'
+            '"id": 45,' => '"id": 46,',
+            '-45"' => '-46"'
         ] : [];
         // TODO: the produced json doesn't contain information about the components that make up the grouped product
         $this->shouldPublishProductEditedUsingMagentoApplicationToStreamx('Set of Sprite Yoga Straps', 'grouped', $regexReplacements);

--- a/test/catalog/integration/AppEntityUpdateStreamxPublishTests/ProductVariantUpdateTest.php
+++ b/test/catalog/integration/AppEntityUpdateStreamxPublishTests/ProductVariantUpdateTest.php
@@ -112,15 +112,15 @@ class ProductVariantUpdateTest extends BaseAppEntityUpdateTest {
         try {
             if ($expectingVariantToBePublished) {
                 $this->assertExactDataIsPublished($expectedChildProductKey, 'original-hoodie-xl-orange-product.json', [
-                    '"' . self::CHILD_PRODUCT_NAME => '"' . $childProductModifiedName,
-                    '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME) => '"' . SlugGenerator::slugify($childProductModifiedName)
+                    '"' . $childProductModifiedName => '"' . self::CHILD_PRODUCT_NAME,
+                    '"' . SlugGenerator::slugify($childProductModifiedName) => '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME)
                 ]);
             } else {
                 $this->assertDataIsNotPublished($expectedChildProductKey);
             }
             $this->assertExactDataIsPublished($expectedParentProductKey, 'original-hoodie-product.json', [
-                '"' . self::CHILD_PRODUCT_NAME => '"' . $childProductModifiedName,
-                '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME) => '"' . SlugGenerator::slugify($childProductModifiedName)
+                '"' . $childProductModifiedName => '"' . self::CHILD_PRODUCT_NAME,
+                '"' . SlugGenerator::slugify($childProductModifiedName) => '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME)
             ]);
             $this->assertDataIsNotPublished($unexpectedChildProductKey);
         } finally {

--- a/test/catalog/integration/BaseStreamxTest.php
+++ b/test/catalog/integration/BaseStreamxTest.php
@@ -28,6 +28,7 @@ abstract class BaseStreamxTest extends TestCase {
     private const SLEEP_MICROS_BETWEEN_DATA_PUBLISH_CHECKS = 200_000;
 
     /**
+     * @param array $regexReplacements what to change in the actual StreamX response Json, to match the validation file
      * @return string the actually published data if assertion passes, or exception if assertion failed
      */
     protected function assertExactDataIsPublished(string $key, string $validationFileName, array $regexReplacements = []): ?string {

--- a/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/CategoryAddAndDeleteTest.php
+++ b/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/CategoryAddAndDeleteTest.php
@@ -26,9 +26,9 @@ class CategoryAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
             // then
             $this->assertExactDataIsPublished($expectedKey, 'added-category.json', [
                 // provide values for placeholders in the validation file
-                123456789 => $category->getEntityId(),
-                'CATEGORY_NAME' => 'The new Category',
-                'CATEGORY_SLUG' => "the-new-category-{$category->getEntityId()}"
+                '"id": ' . $category->getEntityId() => '"id": 123456789',
+                'The new Category' => 'CATEGORY_NAME',
+                "the-new-category-{$category->getEntityId()}" => 'CATEGORY_SLUG'
             ]);
         } finally {
             // and when

--- a/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/MultistoreCategoryAddAndDeleteTest.php
+++ b/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/MultistoreCategoryAddAndDeleteTest.php
@@ -42,9 +42,9 @@ class MultistoreCategoryAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
             // TODO investigate - this assertion sometimes fails
             $this->assertExactDataIsPublished($expectedKeyForStore2, 'added-category.json', [
                 // provide values for placeholders in the validation file
-                123456789 => $category->getEntityId(),
-                'CATEGORY_NAME' => 'Category name in second store',
-                'CATEGORY_SLUG' => "category-name-in-second-store-{$category->getEntityId()}"
+                '"id": ' . $category->getEntityId() => '"id": 123456789',
+                'Category name in second store' => 'CATEGORY_NAME',
+                "category-name-in-second-store-{$category->getEntityId()}" => 'CATEGORY_SLUG'
             ]);
 
             // and
@@ -90,21 +90,21 @@ class MultistoreCategoryAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
             // then
             $this->assertExactDataIsPublished($expectedKeyForStore1, 'added-category.json', [
                 // provide values for placeholders in the validation file
-                123456789 => $store1CategoryId,
-                'CATEGORY_NAME' => 'Bikes for first store',
-                'CATEGORY_SLUG' => "bikes-for-first-store-$store1CategoryId"
+                '"id": ' . $store1CategoryId => '"id": 123456789',
+                'Bikes for first store' => 'CATEGORY_NAME',
+                "bikes-for-first-store-$store1CategoryId" => 'CATEGORY_SLUG'
             ]);
             $this->assertDataIsNotPublished($unexpectedKeyForStore1);
 
             $this->assertExactDataIsPublished($expectedKeyForStore2, 'added-category.json', [
                 // provide values for placeholders in the validation file
-                123456789 => $store2CategoryId,
-                'CATEGORY_NAME' => 'Bikes for second store',
-                'CATEGORY_SLUG' => "bikes-for-second-store-$store2CategoryId",
+                '"id": ' . $store2CategoryId => '"id": 123456789',
+                'Bikes for second store' => 'CATEGORY_NAME',
+                "bikes-for-second-store-$store2CategoryId" => 'CATEGORY_SLUG',
                 // expect different parent category than default
-                '"id": 2,' => '"id": ' . $rootCategoryIdForStore2 . ',',
-                'Default Category' => 'Root category for second store',
-                'default-category-2' => 'root-category-for-second-store-' . $rootCategoryIdForStore2
+                '"id": ' . $rootCategoryIdForStore2 . ',' => '"id": 2,',
+                'Root category for second store' => 'Default Category',
+                'root-category-for-second-store-' . $rootCategoryIdForStore2 => 'default-category-2'
             ]);
             $this->assertDataIsNotPublished($unexpectedKeyForStore2);
         } finally {

--- a/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/MultistoreProductAddAndDeleteTest.php
+++ b/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/MultistoreProductAddAndDeleteTest.php
@@ -153,20 +153,20 @@ class MultistoreProductAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
             // then
             $this->assertExactDataIsPublished($expectedKeyForProduct1, 'added-minimal-product.json', [
                 // provide values for placeholders in the validation file
-                'SKU' => $sku1,
-                123456789 => $product1Id,
-                'PRODUCT_NAME' => 'Name of Product A in second store',
-                'PRODUCT_SLUG' => "name-of-product-a-in-second-store-$product1Id",
-                'VISIBILITY' => 'Search'
+                $sku1 => 'SKU',
+                '"id": ' . $product1Id => '"id": 123456789',
+                'Name of Product A in second store' => 'PRODUCT_NAME',
+                "name-of-product-a-in-second-store-$product1Id" => 'PRODUCT_SLUG',
+                'Search' => 'VISIBILITY'
             ]);
 
             $this->assertExactDataIsPublished($expectedKeyForProduct2, 'added-minimal-product.json', [
                 // provide values for placeholders in the validation file
-                'SKU' => $sku2,
-                123456789 => $product2Id,
-                'PRODUCT_NAME' => 'Name of Product B in first store',
-                'PRODUCT_SLUG' => "name-of-product-b-in-first-store-$product2Id",
-                'VISIBILITY' => 'Catalog'
+                $sku2 => 'SKU',
+                '"id": ' . $product2Id => '"id": 123456789',
+                'Name of Product B in first store' => 'PRODUCT_NAME',
+                "name-of-product-b-in-first-store-$product2Id" => 'PRODUCT_SLUG',
+                'Catalog' => 'VISIBILITY'
             ]);
 
             // and

--- a/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/ProductAddAndDeleteTest.php
+++ b/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/ProductAddAndDeleteTest.php
@@ -34,11 +34,11 @@ class ProductAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
             // then
             $this->assertExactDataIsPublished($expectedKey, 'added-minimal-product.json', [
                 // provide values for placeholders in the validation file
-                'SKU' => $sku,
-                123456789 => $product->getEntityId(),
-                'PRODUCT_NAME' => 'The minimal product',
-                'PRODUCT_SLUG' => "the-minimal-product-{$product->getEntityId()}",
-                'VISIBILITY' => 'Catalog, Search'
+                $sku => 'SKU',
+                '"id": ' . $product->getEntityId() => '"id": 123456789',
+                'The minimal product' => 'PRODUCT_NAME',
+                "the-minimal-product-{$product->getEntityId()}" => 'PRODUCT_SLUG',
+                'Catalog, Search' => 'VISIBILITY'
             ]);
         } finally {
             // and when
@@ -72,14 +72,14 @@ class ProductAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
             // then
             $publishedJson = $this->assertExactDataIsPublished($expectedKey, 'added-watch-product.json', [
                 // mask variable parts (ids and generated sku)
-                '"id": [0-9]+' => '"id": 0',
-                '"sku": "[^"]+"' => '"sku": "[MASKED]"',
-                '"the-new-great-watch-[0-9]+"' => '"the-new-great-watch-0"',
-                '"option_id": "[0-9]+"' => '"option_id": "0"',
-                '"option_type_id": "[0-9]+"' => '"option_type_id": "0"',
+                '"id": [0-9]{4}' => '"id": 2659',
+                '"sku": "[^"]+"' => '"sku": "1736952738"',
+                '"the-new-great-watch-[0-9]+"' => '"the-new-great-watch-2659"',
+                '"option_id": "[0-9]+"' => '"option_id": "9"',
+                '"option_type_id": "[0-9]+"' => '"option_type_id": "7"',
                 // expect the indexed prices to be applied
-                '"value": ' . self::PRODUCT_PRICE => '"value": ' . self::INDEXED_PRICE,
-                '"discountedValue": ' . self::PRODUCT_PRICE => '"discountedValue": ' . self::DISCOUNTED_PRICE
+                '"value": ' . self::INDEXED_PRICE => '"value": ' . self::PRODUCT_PRICE,
+                '"discountedValue": ' . self::DISCOUNTED_PRICE => '"discountedValue": ' . self::PRODUCT_PRICE
             ]);
 
             // and
@@ -161,11 +161,11 @@ class ProductAddAndDeleteTest extends BaseDirectDbEntityUpdateTest {
                 $expectedSlug = str_replace([' ', 'W'], ['-', 'w'], $productName) . "-$productId";
                 $this->assertExactDataIsPublished("default_product:$productId", 'added-minimal-product.json', [
                     // provide values for placeholders in the validation file
-                    'SKU' => $skus[$i],
-                    123456789 => $productId,
-                    'PRODUCT_NAME' => $productName,
-                    'PRODUCT_SLUG' => $expectedSlug,
-                    'VISIBILITY' => 'Catalog, Search'
+                    $skus[$i] => 'SKU',
+                    '"id": ' . $productId => '"id": 123456789',
+                    $productName => 'PRODUCT_NAME',
+                    $expectedSlug => 'PRODUCT_SLUG',
+                    'Catalog, Search' => 'VISIBILITY'
                 ]);
             }
         } finally {

--- a/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/ProductUpdateTest.php
+++ b/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/ProductUpdateTest.php
@@ -26,8 +26,8 @@ class ProductUpdateTest extends BaseDirectDbEntityUpdateTest {
     /** @test */
     public function shouldPublishBundleProductEditedDirectlyInDatabaseToStreamx() {
         $regexReplacements = self::$db->isEnterpriseMagento() ? [ // in enterprise magento DB, ID of the bundle product is 46, not 45 as in community version
-            '"id": 45,' => '"id": 46,',
-            '-45"' => '-46"'
+            '"id": 46,' => '"id": 45,',
+            '-46"' => '-45"'
         ] : [];
         $this->shouldPublishProductEditedDirectlyInDatabaseToStreamx('Sprite Yoga Companion Kit', 'bundle', $regexReplacements);
     }
@@ -35,8 +35,8 @@ class ProductUpdateTest extends BaseDirectDbEntityUpdateTest {
     /** @test */
     public function shouldPublishGroupedProductEditedDirectlyInDatabaseToStreamx() {
         $regexReplacements = self::$db->isEnterpriseMagento() ? [ // in enterprise magento DB, ID of the grouped product is 45, not 46 as in community version
-            '"id": 46,' => '"id": 45,',
-            '-46"' => '-45"'
+            '"id": 45,' => '"id": 46,',
+            '-45"' => '-46"'
         ] : [];
         // TODO: the produced json doesn't contain information about the components that make up the grouped product
         $this->shouldPublishProductEditedDirectlyInDatabaseToStreamx('Set of Sprite Yoga Straps', 'grouped', $regexReplacements);

--- a/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/ProductVariantUpdateTest.php
+++ b/test/catalog/integration/DirectDbEntityUpdateStreamxPublishTests/ProductVariantUpdateTest.php
@@ -112,15 +112,15 @@ class ProductVariantUpdateTest extends BaseDirectDbEntityUpdateTest {
             // note: $expectingVariantToBePublished is passed as a flag, because publishing a variant depends on its visibility setting
             if ($expectingVariantToBePublished) {
                 $this->assertExactDataIsPublished($expectedChildProductKey, 'original-hoodie-xl-orange-product.json', [
-                    '"' . self::CHILD_PRODUCT_NAME => '"' . $childProductModifiedName,
-                    '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME) => '"' . SlugGenerator::slugify($childProductModifiedName)
+                    '"' . $childProductModifiedName => '"' . self::CHILD_PRODUCT_NAME,
+                    '"' . SlugGenerator::slugify($childProductModifiedName) => '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME)
                 ]);
             } else {
                 $this->assertDataIsNotPublished($expectedChildProductKey);
             }
             $this->assertExactDataIsPublished($expectedParentProductKey, 'original-hoodie-product.json', [
-                '"' . self::CHILD_PRODUCT_NAME => '"' . $childProductModifiedName,
-                '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME) => '"' . SlugGenerator::slugify($childProductModifiedName)
+                '"' . $childProductModifiedName => '"' . self::CHILD_PRODUCT_NAME,
+                '"' . SlugGenerator::slugify($childProductModifiedName) => '"' . SlugGenerator::slugify(self::CHILD_PRODUCT_NAME)
             ]);
             $this->assertDataIsNotPublished($unexpectedChildProductKey);
         } finally {

--- a/test/catalog/integration/StreamxConnectorClientAvailabilityTest.php
+++ b/test/catalog/integration/StreamxConnectorClientAvailabilityTest.php
@@ -96,7 +96,7 @@ class StreamxConnectorClientAvailabilityTest extends BaseStreamxTest {
         // then
         for ($i = 0; $i < $entitiesToPublishInBatch; $i++) {
             $this->assertExactDataIsPublished(self::expectedStreamxProductKey($i), 'original-hoodie-product.json', [
-                62 => $i // 62 is the product ID in validation file
+                '^    "id": '. $i . ',' => '    "id": 62,' // 62 is the product ID in validation file
             ]);
         }
 

--- a/test/catalog/integration/utils/ValidationFileUtils.php
+++ b/test/catalog/integration/utils/ValidationFileUtils.php
@@ -22,7 +22,8 @@ trait ValidationFileUtils  {
     private function verifySameJsons(string $expectedFormattedJson, string $actualJson, bool $throwOnAssertionError, array $regexReplacements = []): bool {
         $actualFormattedJson = JsonFormatter::formatJson($actualJson);
         try {
-            $expected = self::standardizeNewlines(self::replaceRegexes($expectedFormattedJson, $regexReplacements));
+            $expected = self::standardizeNewlines($expectedFormattedJson);
+            // allow adjusting actual json to match expected validation json
             $actual = self::standardizeNewlines(self::replaceRegexes($actualFormattedJson, $regexReplacements));
             $this->assertEquals($expected, $actual);
             return true;
@@ -40,7 +41,7 @@ trait ValidationFileUtils  {
 
     private function replaceRegexes(string $json, array $regexReplacements): string {
         foreach ($regexReplacements as $regex => $replacement) {
-            $json = preg_replace('/' . $regex . '/', $replacement, $json);
+            $json = preg_replace("/$regex/m", $replacement, $json);
         }
         return $json;
     }


### PR DESCRIPTION
## 📋 Type of the changes

- [ ] Breaking change
- [ ] Non-breaking change
- [x] Bug fix / minor change

## 🛠 Changes being made

Tighten json-based validation: adjust only actual json to match validation file, not both

## ✅ Checklist

- [x] My code follows the [code standards](https://github.com/streamx-dev/streamx/blob/main/CONTRIBUTING.md) of this project
- [x] Changed code is covered with unit tests
- [ ] I have updated READMEs and java docs (if applicable)
